### PR TITLE
Correct capitalization of filenames in #include directives

### DIFF
--- a/src/thermistor.cpp
+++ b/src/thermistor.cpp
@@ -1,9 +1,9 @@
 
 #include <Arduino.h>
 #include <stdint.h>
-#include <configuration.h>
-#include <tables/conditionals.h>
-#include <tables/thermistortables.h>
+#include <Configuration.h>
+#include <tables/Conditionals.h>
+#include <tables/Thermistortables.h>
 #include <thermistor.h>
 
 #define HOTENDS  1

--- a/thermistor.cpp
+++ b/thermistor.cpp
@@ -1,9 +1,9 @@
 
 #include <Arduino.h>
 #include <stdint.h>
-#include <src/configuration.h>
-#include <src/conditionals.h>
-#include <src/thermistortables.h>
+#include <src/Configuration.h>
+#include <src/Conditionals.h>
+#include <src/Thermistortables.h>
 #include <thermistor.h>
 
 #define HOTENDS  1


### PR DESCRIPTION
Incorrect capitalization of filenames causes compilation to fail on filename case-sensitive operating systems like Linux.