### PR TITLE
Fix #8

### DIFF
--- a/src/thermistor.cpp
+++ b/src/thermistor.cpp
@@ -38,7 +38,7 @@ float thermistor::analog2temp() {
     float celsius = 0;
     uint8_t i;
     short(*tt)[][2] = (short(*)[][2])(heater_ttbl_map[e]);
-    for (i = 1; i < heater_ttbl_map[e]; i++) {
+    for (i = 1; i < heater_ttbllen_map[e]; i++) {
       if (PGM_RD_W((*tt)[i][0]) > raw) {
         celsius = PGM_RD_W((*tt)[i - 1][1]) +
                   (raw - PGM_RD_W((*tt)[i - 1][0])) *


### PR DESCRIPTION
This fixes #8. Thermistor table contents were used instead of thermistor table length to bound the for loop.