### PR TITLE
Library is compatible with STM32 boards

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence= This library allows you to read the thermistors very easily.
 paragraph= This library allows an Arduino/Genuino board to read thermistors very easily.
 category= Sensors
 url=https://github.com/miguel5612/Arduino-ThermistorLibrary
-architectures=avr
+architectures=avr,stm32
 license=MIT


### PR DESCRIPTION
added the stm32 architecture flag to remove the following warning, as this library builds successfully on the STM32Duino Core 
'''WARNING: library ThermistorLibrary claims to run on (avr) architecture(s) and may be incompatible with your current board which runs on (stm32) architecture(s).'''